### PR TITLE
updated: package.json -> script -> start node

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Project 2 Starter",
   "main": "server.js",
   "scripts": {
-    "start": "concurrently \"node server.js\" \"npm run css-watch\"",
+    "start": "node server.js",
     "lint": "eslint **/*.js --quiet",
     "fix": "eslint --fix .",
     "test": "npm run lint && cross-env NODE_ENV=test mocha -u tdd --reporter spec --exit",


### PR DESCRIPTION
There is an error in the Heroku deployment.  In the package.jason script, the start property is set to some funky string that was not there before and it is confusing Heroku deployment.  I'm hoping this fixes the issue.